### PR TITLE
Values: Rename `cluster` into `useClusterEndpoints`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Values: Rename `cluster` into `useClusterEndpoints`. ([#8](https://github.com/giantswarm/etcd-defrag-app/pull/8))
+
 ## [0.1.0] - 2025-01-21
 
 [Unreleased]: https://github.com/giantswarm/etcd-defrag-app/compare/v0.1.0...HEAD

--- a/helm/etcd-defrag/README.md
+++ b/helm/etcd-defrag/README.md
@@ -17,7 +17,6 @@ etcd-defrag is an easy to use and smart etcd defragmentation tool.
 | caCertPath | string | `"/etc/kubernetes/pki/etcd/ca.crt"` | CA certificate path. |
 | clientCertPath | string | `"/etc/kubernetes/pki/apiserver-etcd-client.crt"` | Client certificate path. |
 | clientKeyPath | string | `"/etc/kubernetes/pki/apiserver-etcd-client.key"` | Client key path. |
-| cluster | bool | `true` | Whether to use all endpoints from the cluster member list or not. |
 | defragRule | string | `"dbQuotaUsage > 0.8 && dbSizeFree > dbQuota * 0.1"` | etcd defrag rule.  Available variables:  dbSize:       Total size of the etcd database. dbSizeInUse:  Total size in use of the etcd database. dbSizeFree:   Total size not in use of the etcd database, defined as dbSize - dbSizeInUse. dbQuota:      etcd storage quota in bytes (the value passed to etcd instance by flag --quota-backend-bytes). dbQuotaUsage: Total usage of the etcd storage quota, defined as dbSize/dbQuota.  dbQuota needs to be passed as etcdStorageQuotaBytes.  By default, we defragment if the quota usage is greater than 80% and the unused space makes up 10% of the quota. |
 | endpoints | list | `["https://127.0.0.1:2379"]` | etcd endpoints. |
 | etcdStorageQuotaBytes | int | `8589934592` | etcd storage quota in bytes (defaults to 8Gi). |
@@ -42,3 +41,4 @@ etcd-defrag is an easy to use and smart etcd defragmentation tool.
 | schedule | string | `"0 * * * *"` | Cron schedule. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. |
 | tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"},{"effect":"NoExecute","operator":"Exists"}]` | Tolerations. |
+| useClusterEndpoints | bool | `true` | Whether to use all endpoints from the cluster member list or not. |

--- a/helm/etcd-defrag/templates/cronjob.yaml
+++ b/helm/etcd-defrag/templates/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
             {{- else }}
             {{- fail ".Values.endpoints may not be empty!" }}
             {{- end }}
-            {{- if .Values.cluster }}
+            {{- if .Values.useClusterEndpoints }}
             - --cluster
             {{- end }}
             - --cacert=/ca.crt

--- a/helm/etcd-defrag/values.schema.json
+++ b/helm/etcd-defrag/values.schema.json
@@ -57,9 +57,6 @@
         "clientKeyPath": {
             "type": "string"
         },
-        "cluster": {
-            "type": "boolean"
-        },
         "defragRule": {
             "type": "string"
         },
@@ -206,6 +203,9 @@
                     }
                 }
             }
+        },
+        "useClusterEndpoints": {
+            "type": "boolean"
         }
     }
 }

--- a/helm/etcd-defrag/values.yaml
+++ b/helm/etcd-defrag/values.yaml
@@ -61,7 +61,7 @@ endpoints:
 - https://127.0.0.1:2379
 
 # -- Whether to use all endpoints from the cluster member list or not.
-cluster: true
+useClusterEndpoints: true
 
 # -- etcd storage quota in bytes (defaults to 8Gi).
 etcdStorageQuotaBytes: 8589934592


### PR DESCRIPTION
App deployment fails with the following status:

```yaml
status:
  appVersion: ""
  release:
    lastDeployed: null
    reason: |
      values don't meet the specifications of the schema(s) in the following chart(s):
      etcd-defrag:
      - cluster: Invalid type. Expected: boolean, given: object
    status: values-schema-violation
  version: ""
```

I assume `cluster` to be a value merged into the final values from some global values.